### PR TITLE
fix(houses): change calc base into utc to calc base into calendar day

### DIFF
--- a/src/astrologer/astros.js
+++ b/src/astrologer/astros.js
@@ -2,7 +2,7 @@ const swisseph = require("swisseph");
 
 swisseph.swe_set_ephe_path(`${__dirname}/../../eph`);
 
-const { utcToJulianUt, zodiacSign, degreesToDms } = require("./utils");
+const { utcToJulianEt, utcToJulianUt, zodiacSign, degreesToDms } = require("./utils");
 
 const PLANETS = {
   sun: swisseph.SE_SUN,
@@ -44,12 +44,11 @@ const planetsByType = {
 
 const FLAG = swisseph.SEFLG_SPEED | swisseph.SEFLG_SWIEPH;
 
-const getPositionOfAstro = (astro, julianDayUT) => swisseph.swe_calc_ut(julianDayUT, PLANETS[astro], FLAG);
+const getPositionOfAstro = (astro, julianDay) => swisseph.swe_calc(julianDay, PLANETS[astro], FLAG);
 
 const position = (astrologyObject, moment) => {
-  const julianDayUT = utcToJulianUt(moment);
-  const astro = getPositionOfAstro(astrologyObject, julianDayUT);
-
+  const julianDay = utcToJulianEt(moment);
+  const astro = getPositionOfAstro(astrologyObject, julianDay);
   const dms = degreesToDms(astro.longitude);
   return {
     position: {

--- a/src/astrologer/utils.js
+++ b/src/astrologer/utils.js
@@ -16,6 +16,12 @@ const utcToJulianUt = (utcDate) => {
   );
 };
 
+const utcToJulianEt = (utcDate) => {
+  const julianUt = utcToJulianUt(utcDate);
+  const { delta } = swisseph.swe_deltat(julianUt);
+  return julianUt + delta;
+};
+
 const degreesToDms = (value) => {
   const position = swisseph.swe_split_deg(value, swisseph.SE_SPLIT_DEG_ZODIACAL);
   const { degree: degrees, min: minutes, second: seconds } = position;
@@ -45,5 +51,6 @@ module.exports = {
   utcToJulianUt,
   degreesToDms,
   zodiacSign,
-  normalizeDegrees
+  normalizeDegrees,
+  utcToJulianEt,
 };

--- a/src/astrologer/utils.js
+++ b/src/astrologer/utils.js
@@ -1,21 +1,24 @@
 const swisseph = require("swisseph");
 
 const utcToJulianUt = (utcDate) => {
-  const { julianDayUT } = swisseph.swe_utc_to_jd(
+  const milliSecondsInSeconds = utcDate.getUTCMilliseconds() / 1000;
+  const secondsInMinutes = (utcDate.getUTCSeconds() + milliSecondsInSeconds) / 60;
+  const minutesInHours = (utcDate.getUTCMinutes() + secondsInMinutes) / 60;
+
+  const hours = utcDate.getUTCHours() + minutesInHours;
+
+  return swisseph.swe_julday(
     utcDate.getUTCFullYear(),
     utcDate.getUTCMonth() + 1,
     utcDate.getUTCDate(),
-    utcDate.getUTCHours(),
-    utcDate.getUTCMinutes(),
-    utcDate.getUTCSeconds(),
+    hours,
     swisseph.SE_GREG_CAL
   );
-
-  return julianDayUT;
 };
 
 const degreesToDms = (value) => {
-  const { degree: degrees, min: minutes, second: seconds } = swisseph.swe_split_deg(value, swisseph.SE_SPLIT_DEG_ZODIACAL);
+  const position = swisseph.swe_split_deg(value, swisseph.SE_SPLIT_DEG_ZODIACAL);
+  const { degree: degrees, min: minutes, second: seconds } = position;
 
   return {
     degrees,

--- a/test/features/get-houses-cuspids-in-placidus-system.spec.js
+++ b/test/features/get-houses-cuspids-in-placidus-system.spec.js
@@ -31,66 +31,66 @@ describe("Get placidus houses system cuspids for 1991-07-06T16:50:00-04:00", () 
   };
 
   it("/horoscope return the ASC axis (cuspid of the house I)", () => {
-    expectCuspids(response.body.data.axes.asc, 10, 2, 32, 29);
+    expectCuspids(response.body.data.axes.asc, 10, 2, 32, 26);
   });
 
   it("/horoscope return the DC axis (cuspid of the house VII)", () => {
-    expectCuspids(response.body.data.axes.dc, 4, 2, 32, 29);
+    expectCuspids(response.body.data.axes.dc, 4, 2, 32, 26);
   });
 
   it("/horoscope return the MC axis (cuspid of the house X)", () => {
-    expectCuspids(response.body.data.axes.mc, 6, 14, 58, 46);
+    expectCuspids(response.body.data.axes.mc, 6, 14, 58, 42);
   });
 
   it("/horoscope return the IC axis (cuspid of the house IV)", () => {
-    expectCuspids(response.body.data.axes.ic, 12, 14, 58, 46);
+    expectCuspids(response.body.data.axes.ic, 12, 14, 58, 42);
   });
 
   it("/horoscope response has cuspid of house I", () => {
-    expectCuspids(response.body.data.houses[0], 10, 2, 32, 29);
+    expectCuspids(response.body.data.houses[0], 10, 2, 32, 26);
   });
 
   it("/horoscope response has cuspid of house II", () => {
-    expectCuspids(response.body.data.houses[1], 10, 24, 11, 43);
+    expectCuspids(response.body.data.houses[1], 10, 24, 11, 40);
   });
 
   it("/horoscope response has cuspid of house III", () => {
-    expectCuspids(response.body.data.houses[2], 11, 17, 16, 23);
+    expectCuspids(response.body.data.houses[2], 11, 17, 16, 20);
   });
 
   it("/horoscope response has cuspid of house IV", () => {
-    expectCuspids(response.body.data.houses[3], 12, 14, 58, 46);
+    expectCuspids(response.body.data.houses[3], 12, 14, 58, 42);
   });
 
   it("/horoscope response has cuspid of house V", () => {
-    expectCuspids(response.body.data.houses[4], 1, 19, 20, 11);
+    expectCuspids(response.body.data.houses[4], 1, 19, 20, 6);
   });
 
   it("/horoscope response has cuspid of house VI", () => {
-    expectCuspids(response.body.data.houses[5], 2, 27, 30, 14);
+    expectCuspids(response.body.data.houses[5], 2, 27, 30, 10);
   });
 
   it("/horoscope response has cuspid of house VII", () => {
-    expectCuspids(response.body.data.houses[6], 4, 2, 32, 29);
+    expectCuspids(response.body.data.houses[6], 4, 2, 32, 26);
   });
 
   it("/horoscope response has cuspid of house VIII", () => {
-    expectCuspids(response.body.data.houses[7], 4, 24, 11, 43);
+    expectCuspids(response.body.data.houses[7], 4, 24, 11, 40);
   });
 
   it("/horoscope response has cuspid of house IX", () => {
-    expectCuspids(response.body.data.houses[8], 5, 17, 16, 23);
+    expectCuspids(response.body.data.houses[8], 5, 17, 16, 20);
   });
 
   it("/horoscope response has cuspid of house X", () => {
-    expectCuspids(response.body.data.houses[9], 6, 14, 58, 46);
+    expectCuspids(response.body.data.houses[9], 6, 14, 58, 42);
   });
 
   it("/horoscope response has cuspid of house XI", () => {
-    expectCuspids(response.body.data.houses[10], 7, 19, 20, 11);
+    expectCuspids(response.body.data.houses[10], 7, 19, 20, 6);
   });
 
   it("/horoscope response has cuspid of house XII", () => {
-    expectCuspids(response.body.data.houses[11], 8, 27, 30, 14);
+    expectCuspids(response.body.data.houses[11], 8, 27, 30, 10);
   });
 });

--- a/test/features/get-planets-positions-for-06-07-1991-205000gmt.spec.js
+++ b/test/features/get-planets-positions-for-06-07-1991-205000gmt.spec.js
@@ -30,11 +30,11 @@ describe("Get the planets position for 1991-07-06T16:50:00-04:00", () => {
   };
 
   test("get the sun position", async () => {
-    expectAstro("sun", 4, { degrees: 14, minutes: 16, seconds: 58 });
+    expectAstro("sun", 4, { degrees: 14, minutes: 16, seconds: 57 });
   });
 
   test("get the moon position", async () => {
-    expectAstro("moon", 2, { degrees: 6, minutes: 18, seconds: 54 });
+    expectAstro("moon", 2, { degrees: 6, minutes: 18, seconds: 53 });
   });
 
   test("get the mercury position", async () => {


### PR DESCRIPTION
Previously, this implementation was using the recommended methods for
dates based on Coordinated Universal Time (UTC) [UTC and Julian day: swe_utc_time_zone(), swe_utc_to_jd(), swe_jdet_to_utc(), swe_jdut1_to_utc()](https://www.astro.com/swisseph/swephprg.htm#_Toc71121194). 

These functions are recommended more for hours obtained from clock. The problem with them is that for some calculations they deliver differences with other libraries that use swesseph. Due to standardization issues with other libraries and to avoid confusion, it was decided to replace the implementation to be able to use the dates based on the calendar day.

Also, the functions for calculating the position of the planets are also changed in order to use the functions with Ephemeris time (ET) and leave a little more coherence in the calculations and be closer to what other softwares deliver.

For more info see #15 

Resolve #15 